### PR TITLE
add python >= 3.3 compatible version of xml comment parser

### DIFF
--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -265,7 +265,7 @@ class BeastXml(object):
         if not filename:
             filename = self.config.basename+".xml"
         if filename in ("stdout", "-"):
-            sys.stdout.write(xml_string)
+            sys.stdout.write(xml_string.decode('utf8'))
         else:
             with open(filename, "wb") as fp:
                 fp.write(xml_string)

--- a/tests/extractor_test.py
+++ b/tests/extractor_test.py
@@ -1,7 +1,7 @@
 import os
 import shutil
-
-from nose.tools import *
+import unittest
+from tempfile import mktemp
 
 import beastling.beastxml
 import beastling.configuration
@@ -9,15 +9,21 @@ import beastling.extractor
 
 _test_dir = os.path.dirname(__file__)
 
-def test_extractor():
-    config = beastling.configuration.Configuration(configfile="tests/configs/embed_data.conf")
-    config.process()
-    xml = beastling.beastxml.BeastXml(config)
-    os.makedirs("testing_tmp_dir")
-    os.chdir("testing_tmp_dir")
-    xml.write_file("beastling.xml")
-    beastling.extractor.extract("beastling.xml")
 
-def teardown():
-    os.chdir(os.path.join(_test_dir, ".."))
-    shutil.rmtree("testing_tmp_dir")
+class Tests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = mktemp('testing_tmp_dir')
+        os.mkdir(self.tmp)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp)
+
+    def test_extractor(self):
+        config = beastling.configuration.Configuration(
+            configfile="tests/configs/embed_data.conf")
+        config.process()
+        xml = beastling.beastxml.BeastXml(config)
+        xmlfile = os.path.join(self.tmp, "beastling.xml")
+        xml.write_file(xmlfile)
+        res = beastling.extractor.extract(xmlfile)
+        self.assertTrue(bool(res))

--- a/tests/fileio_tests.py
+++ b/tests/fileio_tests.py
@@ -23,7 +23,8 @@ class Tests(TestCase):
     def test(self):
         beastling_format = load_data(TEST_DATA.joinpath("basic.csv"))
         cldf_format = load_data(TEST_DATA.joinpath("cldf.csv"))
-        assert beastling_format.keys() == cldf_format.keys()
+        assert set(list(beastling_format.keys())) == set(list(cldf_format.keys()))
         for key in beastling_format:
             beastling_format[key].pop("iso")
-            self.assertEqual(beastling_format[key].items(), cldf_format[key].items())
+            self.assertEqual(
+                set(beastling_format[key].items()), set(cldf_format[key].items()))


### PR DESCRIPTION
This was a bit more painful than expected, but seems to work now. I'll add more tests later, but the test suite passes on my end for py2.7 and py3.4.
