### PR TITLE
Enhanced calibration configuration

### DIFF
--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -160,7 +160,12 @@ class BeastXml(object):
                 if clade == "root":
                     langs = self.config.languages
                 else:
-                    langs = [l for l in self.config.languages if any([c==clade for c in [x[0].lower() for x in self.config.classifications[l.lower()]]])]
+                    langs = []
+                    for l in self.config.languages:
+                        for name, glottocode in self.config.classifications[l.lower()]:
+                            if clade == name.lower() or clade == glottocode:
+                                langs.append(l)
+                                break
                 if not langs:
                     continue
                 lower, upper = self.config.calibrations[clade]
@@ -259,9 +264,12 @@ class BeastXml(object):
             tree_logger = ET.SubElement(self.run, "logger", {"mode":"tree", "fileName":self.config.basename+".nex","logEvery":str(self.config.log_every),"id":"treeWithMetaDataLogger"})
             log = ET.SubElement(tree_logger, "log", attrib={"id":"TreeLogger","spec":"beast.evolution.tree.TreeWithMetaDataLogger","tree":"@Tree.t:beastlingTree"})
 
-    def write_file(self, filename=None):
+    def tostring(self):
         indent(self.beast)
-        xml_string = ET.tostring(self.beast, encoding="UTF-8")
+        return ET.tostring(self.beast, encoding="UTF-8")
+
+    def write_file(self, filename=None):
+        xml_string = self.tostring()
         if not filename:
             filename = self.config.basename+".xml"
         if filename in ("stdout", "-"):

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -155,7 +155,8 @@ class Configuration(object):
         ## Calibration
         if p.has_section("calibration"):
             for clade, dates in p.items("calibration"):
-                self.calibrations[clade] = [float(x.strip()) for x in dates.split("-", 1)]
+                self.calibrations[clade.lower()] = [
+                    float(x.strip()) for x in dates.split("-", 1)]
 
         ## Models
         model_sections = [s for s in p.sections() if s.lower().startswith("model")]

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -154,9 +154,12 @@ class Configuration(object):
 
         ## Calibration
         if p.has_section("calibration"):
-            for clade, dates in p.items("calibration"):
-                self.calibrations[clade.lower()] = [
-                    float(x.strip()) for x in dates.split("-", 1)]
+            for clades, dates in p.items("calibration"):
+                for clade in clades.split(','):
+                    clade = clade.strip()
+                    if clade:
+                        self.calibrations[clade.lower()] = [
+                            float(x.strip()) for x in dates.split("-", 1)]
 
         ## Models
         model_sections = [s for s in p.sections() if s.lower().startswith("model")]

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -89,7 +89,7 @@ class Tests(TestCase):
                 'sample_branch_lengths': False,
             },
             'calibration': {
-                'abcd1234': '10-20',
+                'abcd1234, efgh5678': '10-20',
             },
             'model': {
                 'binarised': True,
@@ -103,6 +103,7 @@ class Tests(TestCase):
         self.assertAlmostEqual(cfg.calibrations['abcd1234'][1], 20)
         #self.assertAlmostEqual(cfg.model_configs[0]['minimum_data'], 4.5)
         self.assertTrue(cfg.model_configs[1]['binarised'])
+        self.assertEqual(len(cfg.calibrations), 2)
 
         with self.assertRaisesRegexp(ValueError, 'Value for overlap') as e:
             Configuration(configfile={'languages': {'overlap': 'invalid'}, 'models': {}})

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -146,16 +146,16 @@ class Tests(TestCase):
         config.process()
         self.assertIn('austronesian', config.calibrations)
         v = config.calibrations['austronesian']
-        xml1 = BeastXml(config).tostring()
+        xml1 = BeastXml(config).tostring().decode('utf8')
 
         # Now remove one calibration point ...
         del config.calibrations['austronesian']
-        xml2 = BeastXml(config).tostring()
+        xml2 = BeastXml(config).tostring().decode('utf8')
         self.assertNotEqual(
             len(xml1.split('CalibrationNormal.')), len(xml2.split('CalibrationNormal.')))
 
         # ... and add it back in with using the glottocode:
         config.calibrations['aust1307'] = v
-        xml2 = BeastXml(config).tostring()
+        xml2 = BeastXml(config).tostring().decode('utf8')
         self.assertEqual(
             len(xml1.split('CalibrationNormal.')), len(xml2.split('CalibrationNormal.')))

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -10,6 +10,7 @@ from nose.tools import *
 from mock import patch, Mock
 
 from beastling.configuration import Configuration, get_glottolog_newick
+from beastling.beastxml import BeastXml
 
 
 class Tests(TestCase):
@@ -138,3 +139,22 @@ class Tests(TestCase):
     def bad_overlap(self):
         cfg = self._make_bad_cfg("bad_overlap")
         cfg.process()
+
+    def test_calibration(self):
+        config = self._make_cfg('calibration')
+        config.process()
+        self.assertIn('austronesian', config.calibrations)
+        v = config.calibrations['austronesian']
+        xml1 = BeastXml(config).tostring()
+
+        # Now remove one calibration point ...
+        del config.calibrations['austronesian']
+        xml2 = BeastXml(config).tostring()
+        self.assertNotEqual(
+            len(xml1.split('CalibrationNormal.')), len(xml2.split('CalibrationNormal.')))
+
+        # ... and add it back in with using the glottocode:
+        config.calibrations['aust1307'] = v
+        xml2 = BeastXml(config).tostring()
+        self.assertEqual(
+            len(xml1.split('CalibrationNormal.')), len(xml2.split('CalibrationNormal.')))


### PR DESCRIPTION
Calibration points can now be specified using glottocodes instead of sub-group names. It is also possible to specify a date range for several sub-groups, using syntax like

```
abcd1234, efgh5678 = 1000-2000
```
