### PR TITLE
Also test data readers when it's explicitly cldf

### DIFF
--- a/beastling/fileio/datareaders.py
+++ b/beastling/fileio/datareaders.py
@@ -17,7 +17,7 @@ def load_data(filename, file_format=None, lang_column=None):
         if str(filename).lower().endswith("csv") or filename == "stdin":
             dialect = "excel"
         elif str(filename).lower().endswith("tsv"):
-            dialect = "excel_tab"
+            dialect = "excel-tab"
         else:
             raise ValueError("CLDF standard dictates that filenames must end in .csv or .tsv")
     else:

--- a/tests/fileio_tests.py
+++ b/tests/fileio_tests.py
@@ -19,11 +19,21 @@ class Tests(TestCase):
     def test(self):
         beastling_format = load_data(data_path("basic.csv"))
         cldf_format = load_data(data_path("cldf.csv"))
+        explicit_cldf_format = load_data(data_path("cldf.csv"),
+                                file_format='cldf')
         tabbed_cldf_format = load_data(data_path("cldf.tsv"))
+        tabbed_explicit_cldf_format = load_data(data_path("cldf.tsv"),
+                                                file_format='cldf')
         assert set(list(beastling_format.keys())) == set(list(cldf_format.keys()))
+        assert set(list(beastling_format.keys())) == set(list(explicit_cldf_format.keys()))
         assert set(list(beastling_format.keys())) == set(list(tabbed_cldf_format.keys()))
+        assert set(list(beastling_format.keys())) == set(list(tabbed_explicit_cldf_format.keys()))
         for key in beastling_format:
             self.assertEqual(
                 set(beastling_format[key].items()), set(cldf_format[key].items()))
             self.assertEqual(
+                set(beastling_format[key].items()), set(explicit_cldf_format[key].items()))
+            self.assertEqual(
                 set(beastling_format[key].items()), set(tabbed_cldf_format[key].items()))
+            self.assertEqual(
+                set(beastling_format[key].items()), set(tabbed_explicit_cldf_format[key].items()))


### PR DESCRIPTION
Add tests for when `cldf` is explicitly specified, confirming the fix for #86 given in an earlier pull request.
