### PR TITLE
Remove recommonmark use

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -282,13 +282,4 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
-# -- Markup support
-from recommonmark.parser import CommonMarkParser
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
-
-source_suffix = ['.rst', '.md']
-
 autodoc_member_order = 'groupwise'


### PR DESCRIPTION
I just tried to build the docs using sphinx, which fell over the – now unused – `recommonmark` import. So I removed it.

(If we were using `md`, both `Sphinx` and `recommonmark` should probably be defined requirements, and it may be that the appropriate place for that would be

```
extras_require={'documentation': ['Sphinx', 'recommonmark']}
```

in `setup()`?)
