### PR TITLE
Fix problem with kml path in config files

### DIFF
--- a/tests/configs/geo_prior.conf
+++ b/tests/configs/geo_prior.conf
@@ -1,2 +1,2 @@
 [geo_priors]
-Austronesian = tests/kmls/taiwan.kml
+Austronesian = ../kmls/taiwan.kml


### PR DESCRIPTION
Paths in config files are generally a bit problematic in terms of
portability. Should relative paths be resolved relative to the current
working directory, or to the path of the (which?) config file?

So a partial solution to this problem is implemented here, fixing at
least our problem of making test configs portable in the sense that they
can be read and used within a temporary directory: If configuration
comes from a file, the directory of this file is stored and any path
in the configuration is changed to an absolute path, in case it can be
interpreted as path relative to the config directory. Of course this
opens up the potential problem that a path may exist both, relative to
the configuration directory and relative to the current working directory.
If we consider this problem real, we should make the path lookup algorithm
explicit and configurable.