### PR TITLE
Unify reconstruct_at and calibration logic

### DIFF
--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -193,7 +193,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
                 initial_height = exp(cal.param1)
             elif cal.dist == "uniform":
                 initial_height = (cal.param1  + cal.param2) / 2.0
-            string_bits.append("{:s} = {:}".format(cal.langs[0], initial_height))
+            string_bits.append("{:s} = {:}".format(next(cal.langs.__iter__()), initial_height))
         trait_string = ",\n".join(string_bits)
 
         datetrait = ET.SubElement(self.tree, "trait",
@@ -550,7 +550,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
         # Add a Tip Date scaling operator if required
         if self.config.tip_calibrations and self.config.sample_branch_lengths:
             # Get a list of taxa with non-point tip cals
-            tip_taxa = [cal.langs[0] for cal in self.config.tip_calibrations.values() if cal.dist != "point"]
+            tip_taxa = [next(cal.langs.__iter__()) for cal in self.config.tip_calibrations.values() if cal.dist != "point"]
             for taxon in tip_taxa:
                 tiprandomwalker = ET.SubElement(self.run, "operator",
                     {"id": "TipDatesandomWalker:%s" % taxon,

--- a/beastling/clocks/prior.py
+++ b/beastling/clocks/prior.py
@@ -1,0 +1,34 @@
+import xml.etree.ElementTree as ET
+
+from .baseclock import BaseClock
+from .strict import StrictClock
+
+
+class RatePriorClock (BaseClock):
+    # Class stub for putting priors on clock rates
+    def __init__(self, clock_config, global_config):
+        super().__init__(clock_config, global_config)
+        self.prior = clock_config.get(
+            "prior", "lognormal(-6.9077552789821368, 2.3025850929940459)")
+        self.initial_mean = 1e-3
+
+    def add_prior(self, prior):
+        # TODO: Lift some logic from beastxml.BeastXML.add_calibration
+        # and surroundings to parse prior specifications.
+
+        # Uniform prior on mean clock rate
+        sub_prior = ET.SubElement(
+            prior, "prior",
+            {"id": "clockPrior:%s" % self.name,
+             "name": "distribution",
+             "x": "@clockRate.c:%s" % self.name})
+        ET.SubElement(
+            sub_prior, "LogNormal",
+            {"id": "UniformClockPrior:%s" % self.name,
+             "name": "distr",
+             "M": "-6.9077552789821368",
+             "S": "2.3025850929940459"})
+
+
+class StrictClockWithPrior (RatePriorClock, StrictClock):
+    pass

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -498,7 +498,7 @@ class Configuration(object):
         for name, specification in self.language_group_configs.items():
             taxa = set()
             for already_defined in specification.split(","):
-                taxa |= self.language_group(already_defined.strip())
+                taxa |= set(self.language_group(already_defined.strip()))
             self.language_groups[name] = taxa
 
     def load_glottolog_data(self):
@@ -1019,6 +1019,11 @@ class Configuration(object):
         except KeyError:
             langs = self.get_languages_by_glottolog_clade(clade)
             self.language_groups[clade] = langs
+            if not langs:
+                raise ValueError(
+                    "Language group or Glottolog clade {:} not found "
+                    "or was empty for the languages given.".format(
+                        clade))
             return langs
 
     def instantiate_calibrations(self):
@@ -1232,7 +1237,7 @@ class Configuration(object):
         """
         If the provided value is a filename, read the contents and treat it
         as a Newick tree specification.  Otherwise, assume the provided value
-        is a Neick tree specification.  In either case, inspect the tree and
+        is a Newick tree specification.  In either case, inspect the tree and
         make appropriate minor changes so it is suitable for inclusion in the
         BEAST XML file.
         """

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -21,6 +21,7 @@ from beastling.fileio.datareaders import load_location_data
 import beastling.clocks.strict as strict
 import beastling.clocks.relaxed as relaxed
 import beastling.clocks.random as random_clock
+import beastling.clocks.prior as prior_clock
 
 import beastling.models.geo as geo
 import beastling.models.bsvs as bsvs
@@ -810,7 +811,9 @@ class Configuration(object):
         self.clocks_by_name = {}
         for config in self.clock_configs:
             if config["type"].lower() == "strict":
-                clock = strict.StrictClock(config, self) 
+                clock = strict.StrictClock(config, self)
+            elif config["type"].lower() == "strict_with_prior":
+                clock = prior_clock.StrictClockWithPrior(config, self)
             elif config["type"].lower() == "relaxed":
                 clock = relaxed.relaxed_clock_factory(config, self)
             elif config["type"].lower() == "random":

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -1041,7 +1041,7 @@ class Configuration(object):
             # identifier
             langs = self.language_group(clade)
 
-            if langs == self.language_group["root"] and originate:
+            if langs == self.language_groups["root"] and originate:
                 raise ValueError("Root has no ancestor, but originate(root) was given a calibration.")
 
             # Figure out what kind of calibration this is and whether it's valid

--- a/beastling/models/basemodel.py
+++ b/beastling/models/basemodel.py
@@ -290,6 +290,8 @@ class BaseModel(object):
 
     def compute_weights(self):
         self.weights = []
+        # Weights feed into a DeltaExchangeOperator, so they need to
+        # be integers. This is currently implicit, not enforced.
         if self.rate_partition:
             parts = list(self.rate_partition.values())
             partition_weights = {p:parts.count(p) for p in parts}

--- a/beastling/models/basemodel.py
+++ b/beastling/models/basemodel.py
@@ -456,7 +456,8 @@ class BaseModel(object):
                     distribution.attrib["spec"] = "lucl.beast.statereconstruction.AncestralStatesLogger"
                     distribution.attrib["value"] = " ".join(self.pattern_names(f))
                     for label in self.reconstruct_at:
-                        self.beastxml.add_taxon_set(distribution, label, self.config.language_groups[label])
+                        langs = self.config.language_group(label)
+                        self.beastxml.add_taxon_set(distribution, label, langs)
                     self.metadata.append(attribs["id"])
                 distribution.attrib["useAmbiguities"] = "false"
 

--- a/tests/configs/bad_configs/cal_originate_root.conf
+++ b/tests/configs/bad_configs/cal_originate_root.conf
@@ -1,0 +1,13 @@
+[admin]
+basename = beastling_test
+log_probabilities = False
+log_params = False
+log_trees = False
+[MCMC]
+chainlength = 10
+[model model]
+data = ./tests/data/basic.csv
+model = mk
+frequencies = empirical
+[calibration]
+originate(root) = 4.8 - 5.2

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -142,6 +142,11 @@ class Tests(WithConfigAndTempDir):
         cfg.process()
 
     @raises(ValueError)
+    def test_originate_root(self):
+        cfg = self._make_bad_cfg("cal_originate_root")
+        cfg.process()
+
+    @raises(ValueError)
     def test_bad_frequencies(self):
         cfg = self._make_bad_cfg("bad_frequencies")
         cfg.process()


### PR DESCRIPTION
Calibration clades are now defined in terms of language_groups, but
the language_group method provides a way to access explicitly defined
groups with fallback to glottolog clades (including language families
by name).