### PR TITLE
Separate tree handling out to a separate module

### DIFF
--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -203,99 +203,20 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
         """
         Add tree-related <state> sub-elements.
         """
-        self.tree = ET.SubElement(self.state, "tree", {"id":"Tree.t:beastlingTree", "name":"stateNode"})
-        self.add_taxon_set(self.tree, "taxa", self.config.languages, define_taxa=True)
-        if self.config.tree_prior in ["yule", "birthdeath"]:
-            param = ET.SubElement(self.state, "parameter", {"id":"birthRate.t:beastlingTree","name":"stateNode"})
-            if self.birthrate_estimate is not None:
-                param.text=str(self.birthrate_estimate)
-            else:
-                param.text="1.0"
-            if self.config.tree_prior in ["birthdeath"]:
-                ET.SubElement(self.state, "parameter",
-                              {"id": "deathRate.t:beastlingTree",
-                               "name": "stateNode"}).text = "0.5"
-                ET.SubElement(self.state, "parameter",
-                              {"id": "sampling.t:beastlingTree",
-                               "name": "stateNode"}).text = "0.2"
-
-        elif self.config.tree_prior == "coalescent":
-            param = ET.SubElement(self.state, "parameter", {"id":"popSize.t:beastlingTree","name":"stateNode"})
-            param.text="1.0"
-        if self.config.tip_calibrations:
-            self.add_tip_heights()
+        self.config.treeprior.add_state_nodes(self)
 
     def add_init(self):
         """
         Add the <init> element and all its descendants.
         """
-
-        # If a starting tree is specified, use it...
-        if self.config.starting_tree:
-            self.init = ET.SubElement(self.run, "init", {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "spec":"beast.util.TreeParser","IsLabelledNewick":"true", "newick":self.config.starting_tree})
-        # ...if not, use the simplest random tree initialiser possible
-        else:
-            # If we have non-trivial monophyly constraints, use ConstrainedRandomTree
-            if self.config.monophyly and len(self.config.languages) > 2:
-                self.add_constrainedrandomtree_init()
-            # If we have hard-bound calibrations, use SimpleRandomTree
-            elif any([c.dist == "uniform" for c in self.config.calibrations.values()]):
-                self.add_simplerandomtree_init()
-            # Otherwise, just use RandomTree
-            else:
-                self.add_randomtree_init()
+        self.config.treeprior.add_init(self)
 
     def estimate_tree_height(self):
         """
         Make a rough estimate of what the starting height of the tree should
         be so we can initialise somewhere decent.
         """
-        birthrate_estimates = []
-        for cal in self.config.calibrations.values():
-            if len(cal.langs) == 1 or cal.dist not in ("normal", "lognormal"):
-                continue
-            # Find the midpoint of this cal
-            mid = cal.mean()
-            # Find the Yule birthrate which results in an expected height for
-            # a tree of this many taxa which equals the midpoint of the
-            # calibration.
-            # The expected height of a Yule tree with n taxa and
-            # birthrate λ is 1/λ * (Hn - 1), where Hn is the nth
-            # harmonic number.  Hn can be asymptotically approximated
-            # by Hn = log(n) + 0.5772156649. So λ = (Hn - 1) / h.
-            birthrate = (log(len(cal.langs)) + 0.5772156649 - 1) / mid
-            birthrate_estimates.append(birthrate)
-        # If there were no calibrations that could be used, return a non-esitmate
-        if not birthrate_estimates:
-            self.birthrate_estimate = None
-            self.treeheight_estimate = None
-            return
-        # Find the mean birthrate estimate
-        self.birthrate_estimate = round(sum(birthrate_estimates) / len(birthrate_estimates), 4)
-        # Find the expected height of a tree with this birthrate
-        self.treeheight_estimate = round((1.0/self.birthrate_estimate)*(log(len(self.config.languages)) + 0.5772156649 - 1), 4)
-
-    def add_randomtree_init(self):
-        attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.RandomTree"}
-        if self.birthrate_estimate is not None:
-            attribs["rootHeight"] = str(self.treeheight_estimate)
-        self.init = ET.SubElement(self.run, "init", attribs)
-        popmod = ET.SubElement(self.init, "populationModel", {"spec":"ConstantPopulation"})
-        ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})
-
-    def add_simplerandomtree_init(self):
-        attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.SimpleRandomTree"}
-        if self.birthrate_estimate is not None:
-            attribs["rootHeight"] = str(self.treeheight_estimate)
-        self.init = ET.SubElement(self.run, "init", attribs)
-
-    def add_constrainedrandomtree_init(self):
-        attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.ConstrainedRandomTree", "constraints":"@constraints"}
-        if self.birthrate_estimate is not None:
-            attribs["rootHeight"] = str(self.treeheight_estimate)
-        self.init = ET.SubElement(self.run, "init", attribs)
-        popmod = ET.SubElement(self.init, "populationModel", {"spec":"ConstantPopulation"})
-        ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})
+        self.config.treeprior.estimate_height(self)
 
     def add_distributions(self):
         """
@@ -326,7 +247,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
             attribs = {}
             attribs["id"] = "constraints"
             attribs["spec"] = "beast.math.distributions.MultiMonophyleticConstraint"
-            attribs["tree"] = "@Tree.t:beastlingTree"
+            attribs["tree"] = "@{:}".format(self.config.treeprior.tree_id)
             attribs["newick"] = self.config.monophyly_newick
             ET.SubElement(self.prior, "distribution", attribs)
 
@@ -347,7 +268,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
             attribs["id"] = clade + "MRCA"
             attribs["monophyletic"] = "true"
             attribs["spec"] = "beast.math.distributions.MRCAPrior"
-            attribs["tree"] = "@Tree.t:beastlingTree"
+            attribs["tree"] = "@{:}".format(self.config.treeprior.tree_id)
             if cal.originate:
                 attribs["useOriginate"] = "true"
             elif len(cal.langs) == 1:   # If there's only 1 lang and it's not an originate cal, it must be a tip cal
@@ -401,77 +322,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
         self._taxon_sets[label] = langs
 
     def add_tree_prior(self):
-        if self.config.tree_prior.lower() == "yule":
-            self.add_yule_tree_prior()
-        elif self.config.tree_prior.lower() == "birthdeath":
-            self.add_birthdeath_tree_prior()
-        elif self.config.tree_prior.lower() == "coalescent":
-            self.add_coalescent_tree_prior()
-        elif self.config.tree_prior.lower() == "uniform":
-            pass
-        else:
-            raise ValueError("Tree prior {:} is unknown.".format(
-                self.config.tree_prior.lower()))
-
-    def add_yule_tree_prior(self):
-        """
-        Add Yule birth-process tree prior.
-        """
-        # Tree prior
-        ## Decide whether to use the standard Yule or the fancy calibrated one
-        if len(self.config.calibrations) == 1:
-            yule = "calibrated"
-        elif len(self.config.calibrations) == 2:
-            # Two calibrations can be handled by the calibrated Yule if they
-            # are nested
-            langs1, langs2 = [c.langs for c in self.config.calibrations.values()]
-            if len(set(langs1) & set(langs2)) in (len(langs1), len(langs2)):
-                yule = "calibrated"
-            else:
-                yule = "standard"
-        else:
-            yule = "standard"
-
-        attribs = {}
-        attribs["id"] = "YuleModel.t:beastlingTree"
-        attribs["tree"] = "@Tree.t:beastlingTree"
-        if yule == "standard":
-            attribs["spec"] = "beast.evolution.speciation.YuleModel"
-            attribs["birthDiffRate"] = "@birthRate.t:beastlingTree"
-            if "root" in self.config.calibrations:
-                attribs["conditionalOnRoot"] = "true"
-        elif yule == "calibrated":
-            attribs["spec"] = "beast.evolution.speciation.CalibratedYuleModel"
-            attribs["birthRate"] = "@birthRate.t:beastlingTree"
-        ET.SubElement(self.prior, "distribution", attribs)
-
-        # Birth rate prior
-        attribs = {}
-        attribs["id"] = "YuleBirthRatePrior.t:beastlingTree"
-        attribs["name"] = "distribution"
-        attribs["x"] = "@birthRate.t:beastlingTree"
-        sub_prior = ET.SubElement(self.prior, "prior", attribs)
-        uniform = ET.SubElement(sub_prior, "Uniform", {"id":"Uniform.0","name":"distr","upper":"Infinity"})
-
-    def add_coalescent_tree_prior(self):
-
-        coalescent = ET.SubElement(self.prior, "distribution", {
-            "id": "Coalescent.t:beastlingTree",
-            "spec": "Coalescent",
-            })
-        popmod = ET.SubElement(coalescent, "populationModel", {
-            "id": "ConstantPopulation:beastlingTree",
-            "spec": "ConstantPopulation",
-            })
-        ET.SubElement(popmod, "parameter", {
-            "idref": "popSize.t:beastlingTree",
-            "name": "popSize",
-            })
-        ET.SubElement(coalescent, "treeIntervals", {
-            "id": "TreeIntervals",
-            "spec": "TreeIntervals",
-            "tree": "@Tree.t:beastlingTree",
-            })
+        self.config.treeprior.add_prior(self)
 
     def add_likelihood(self):
         """
@@ -515,68 +366,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
 
 
     def add_tree_operators(self):
-        """
-        Add all <operator>s which act on the tree topology and branch lengths.
-        """
-        # Tree operators
-        # Operators which affect the tree must respect the sample_topology and
-        # sample_branch_length options.
-        if self.config.sample_topology:
-            ## Tree topology operators
-            ET.SubElement(self.run, "operator", {"id":"SubtreeSlide.t:beastlingTree","spec":"SubtreeSlide","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"15.0"})
-            ET.SubElement(self.run, "operator", {"id":"narrow.t:beastlingTree","spec":"Exchange","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"15.0"})
-            ET.SubElement(self.run, "operator", {"id":"wide.t:beastlingTree","isNarrow":"false","spec":"Exchange","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"3.0"})
-            ET.SubElement(self.run, "operator", {"id":"WilsonBalding.t:beastlingTree","spec":"WilsonBalding","tree":"@Tree.t:beastlingTree","markclades":"true","weight":"3.0"})
-        if self.config.sample_branch_lengths:
-            ## Branch length operators
-            ET.SubElement(self.run, "operator", {"id":"UniformOperator.t:beastlingTree","spec":"Uniform","tree":"@Tree.t:beastlingTree","weight":"30.0"})
-            ET.SubElement(self.run, "operator", {"id":"treeScaler.t:beastlingTree","scaleFactor":"0.5","spec":"ScaleOperator","tree":"@Tree.t:beastlingTree","weight":"3.0"})
-            ET.SubElement(self.run, "operator", {"id":"treeRootScaler.t:beastlingTree","scaleFactor":"0.5","spec":"ScaleOperator","tree":"@Tree.t:beastlingTree","rootOnly":"true","weight":"3.0"})
-            ## Up/down operator which scales tree height
-            if self.config.tree_prior in ["yule", "birthdeath"]:
-                updown = ET.SubElement(self.run, "operator", {"id":"UpDown","spec":"UpDownOperator","scaleFactor":"0.5", "weight":"3.0"})
-                ET.SubElement(updown, "tree", {"idref":"Tree.t:beastlingTree", "name":"up"})
-                ET.SubElement(updown, "parameter", {"idref":"birthRate.t:beastlingTree", "name":"down"})
-                ### Include clock rates in up/down only if calibrations are given
-                if self.config.calibrations:
-                    for clock in self.config.clocks:
-                        if clock.estimate_rate:
-                            ET.SubElement(updown, "parameter", {"idref":clock.mean_rate_id, "name":"down"})
-
-        if self.config.tree_prior in ["yule", "birthdeath"]:
-            # Birth rate scaler
-            # Birth rate is *always* scaled.
-            ET.SubElement(self.run, "operator", {"id":"YuleBirthRateScaler.t:beastlingTree","spec":"ScaleOperator","parameter":"@birthRate.t:beastlingTree", "scaleFactor":"0.5", "weight":"3.0"})
-        elif self.config.tree_prior == "coalescent":
-            ET.SubElement(self.run, "operator", {"id":"PopulationSizeScaler.t:beastlingTree","spec":"ScaleOperator","parameter":"@popSize.t:beastlingTree", "scaleFactor":"0.5", "weight":"3.0"})
-
-        if self.config.tree_prior in ["birthdeath"]:
-            ET.SubElement(self.run, "operator",
-                          {"id": "SamplingScaler.t:beastlingTree",
-                           "spec": "ScaleOperator",
-                           "parameter": "@sampling.t:beastlingTree",
-                           "scaleFactor": "0.8",
-                           "weight": "1.0"})
-            ET.SubElement(self.run, "operator",
-                          {"id": "DeathRateScaler.t:beastlingTree",
-                           "spec": "ScaleOperator",
-                           "parameter": "@deathRate.t:beastlingTree",
-                           "scaleFactor": "0.5",
-                           "weight": "3.0"})
- 
-        # Add a Tip Date scaling operator if required
-        if self.config.tip_calibrations and self.config.sample_branch_lengths:
-            # Get a list of taxa with non-point tip cals
-            tip_taxa = [next(cal.langs.__iter__()) for cal in self.config.tip_calibrations.values() if cal.dist != "point"]
-            for taxon in tip_taxa:
-                tiprandomwalker = ET.SubElement(self.run, "operator",
-                    {"id": "TipDatesandomWalker:%s" % taxon,
-                     "spec": "TipDatesRandomWalker",
-                     "windowSize": "1",
-                     "tree": "@Tree.t:beastlingTree",
-                     "weight": "3.0",
-                     })
-                self.add_taxon_set(tiprandomwalker, taxon, (taxon,))
+        self.config.treeprior.add_operators(self)
 
     def add_loggers(self):
         """
@@ -616,26 +406,11 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
             ET.SubElement(tracer_logger,"log",{"idref":"posterior"})
         # Log Yule birth rate
         if self.config.log_params:
-            if self.config.tree_prior in ["yule", "birthdeath"]:
-                ET.SubElement(tracer_logger,"log",{"idref":"birthRate.t:beastlingTree"})
-                if self.config.tree_prior in ["birthdeath"]:
-                    ET.SubElement(tracer_logger, "log",
-                                  {"idref": "deathRate.t:beastlingTree"})
-                    ET.SubElement(tracer_logger, "log",
-                                  {"idref": "sampling.t:beastlingTree"})
-            elif self.config.tree_prior == "coalescent":
-                ET.SubElement(tracer_logger,"log",{"idref":"popSize.t:beastlingTree"})
+            self.config.treeprior.add_logging(self, tracer_logger)
             for clock in self.config.clocks:
                 clock.add_param_logs(tracer_logger)
             for model in self.config.all_models:
                 model.add_param_logs(tracer_logger)
-
-        # Log tree height
-        if not self.config.tree_logging_pointless:
-            ET.SubElement(tracer_logger,"log",{
-                "id":"treeStats",
-                "spec":"beast.evolution.tree.TreeStatLogger",
-                "tree":"@Tree.t:beastlingTree"})
 
         # Log calibration clade heights
         for clade, cal in sorted(itertools.chain(self.config.calibrations.items(), self.config.tip_calibrations.items())):
@@ -644,11 +419,6 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
                 continue
             clade = clade.replace(" ","_")
             ET.SubElement(tracer_logger,"log",{"idref":"%sMRCA" % clade})
-
-        # Fine-grained logging
-        if self.config.log_fine_probs:
-            ET.SubElement(tracer_logger,"log",{"idref":"YuleModel.t:beastlingTree"})
-            ET.SubElement(tracer_logger,"log",{"idref":"YuleBirthRatePrior.t:beastlingTree"})
 
     def add_tree_loggers(self):
         """
@@ -688,7 +458,11 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
 
     def add_tree_logger(self, suffix="", branchrate_model_id=None, locations=False):
         tree_logger = ET.SubElement(self.run, "logger", {"mode":"tree", "fileName":self.config.basename + suffix + ".nex", "logEvery":str(self.config.log_every),"id":"treeLogger" + suffix})
-        log = ET.SubElement(tree_logger, "log", attrib={"id":"TreeLoggerWithMetaData"+suffix,"spec":"beast.evolution.tree.TreeWithMetaDataLogger","tree":"@Tree.t:beastlingTree", "dp":str(self.config.log_dp)})
+        log = ET.SubElement(tree_logger, "log", attrib={
+            "id": "TreeLoggerWithMetaData" + suffix,
+            "spec": "beast.evolution.tree.TreeWithMetaDataLogger",
+            "tree": "@{:}".format(self.config.treeprior.tree_id),
+            "dp": str(self.config.log_dp)})
         if branchrate_model_id:
             ET.SubElement(log, "branchratemodel", {"idref":branchrate_model_id})
         if locations:
@@ -699,7 +473,11 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
 
     def add_trait_tree_logger(self, suffix=""):
         tree_logger = ET.SubElement(self.run, "logger", {"mode":"tree", "fileName":self.config.basename + suffix + ".nex", "logEvery":str(self.config.log_every),"id":"treeLogger" + suffix})
-        log = ET.SubElement(tree_logger, "log", attrib={"id":"ReconstructedStateTreeLogger","spec":"beast.evolution.tree.TreeWithTraitLogger","tree":"@Tree.t:beastlingTree"})
+        log = ET.SubElement(tree_logger, "log", attrib={
+            "id": "ReconstructedStateTreeLogger",
+            "spec": "beast.evolution.tree.TreeWithTraitLogger",
+            "tree": "@{:}".format(self.config.treeprior.tree_id)
+        })
         for model in self.config.models:
             for md in model.treedata:
                 ET.SubElement(log, "metadata", {"idref": md})

--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -179,31 +179,14 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
         Add the <state> element and all its descendants.
         """
         self.state = ET.SubElement(self.run, "state", {"id":"state","storeEvery":"5000"})
-        self.add_tree_state()
+        self.config.treeprior.add_state_nodes(self)
         for clock in self.config.clocks:
             clock.add_state(self.state)
         for model in self.config.all_models:
             model.add_state(self.state)
 
     def add_tip_heights(self):
-        string_bits = []
-        for cal in self.config.tip_calibrations.values():
-            initial_height = cal.mean()
-            string_bits.append("{:s} = {:}".format(next(cal.langs.__iter__()), initial_height))
-        trait_string = ",\n".join(string_bits)
-
-        datetrait = ET.SubElement(self.tree, "trait",
-                      {"id": "datetrait",
-                       "spec": "beast.evolution.tree.TraitSet",
-                       "taxa": "@taxa",
-                       "traitname": "date-backward"})
-        datetrait.text = trait_string
-
-    def add_tree_state(self):
-        """
-        Add tree-related <state> sub-elements.
-        """
-        self.config.treeprior.add_state_nodes(self)
+        self.config.treeprior.add_tip_heights(self)
 
     def add_init(self):
         """
@@ -281,7 +264,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
             self.add_taxon_set(cal_prior, taxonsetname, cal.langs)
 
             cal.generate_xml_element(cal_prior)
-            
+
     def add_taxon_set(self, parent, label, langs, define_taxa=False):
         """
         Add a TaxonSet element with the specified set of languages.

--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -186,9 +186,6 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
         for model in self.config.all_models:
             model.add_state(self.state)
 
-    def add_tip_heights(self):
-        self.config.treeprior.add_tip_heights(self)
-
     def add_init(self):
         """
         Add the <init> element and all its descendants.

--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -53,6 +53,7 @@ class BeastXml(object):
         attribs["namespace"] = "beast.core:beast.evolution.alignment:beast.evolution.tree.coalescent:beast.core.util:beast.evolution.nuc:beast.evolution.operators:beast.evolution.sitemodel:beast.evolution.substitutionmodel:beast.evolution.likelihood"
         attribs["version"] ="2.0"
         self.beast = ET.Element("beast", attrib=attribs)
+        self.add_taxon_set(self.beast, "taxa", self.config.languages, define_taxa=True)
         self.add_beastling_comment()
         self.embed_data()
         self.add_maps()

--- a/beastling/beastxml.py
+++ b/beastling/beastxml.py
@@ -217,7 +217,7 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
         self.prior = ET.SubElement(self.posterior,"distribution",{"id":"prior","spec":"util.CompoundDistribution"})
         self.add_monophyly_constraints()
         self.add_calibrations()
-        self.add_tree_prior()
+        self.config.treeprior.add_prior(self)
         for clock in self.config.clocks:
             clock.add_prior(self.prior)
         for model in self.config.all_models:
@@ -304,9 +304,6 @@ java -cp $(java.class.path) beast.app.beastapp.BeastMain $(resume/overwrite) -ja
             for lang in langs:
                 ET.SubElement(taxonset, "taxon", {"id" if define_taxa else "idref" : lang})
         self._taxon_sets[label] = langs
-
-    def add_tree_prior(self):
-        self.config.treeprior.add_prior(self)
 
     def add_likelihood(self):
         """

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -29,6 +29,8 @@ import beastling.models.bsvs as bsvs
 import beastling.models.covarion as covarion
 import beastling.models.mk as mk
 
+from beastling.treepriors.base import TreePrior
+
 _BEAST_MAX_LENGTH = 2147483647
 GLOTTOLOG_NODE_LABEL = re.compile(
     "'(?P<name>[^\[]+)\[(?P<glottocode>[a-z0-9]{8})\](\[(?P<isocode>[a-z]{3})\])?(?P<appendix>-l-)?'")
@@ -183,6 +185,8 @@ class Configuration(object):
         """Number of languages to subsample from the set defined by the dataset(s) and other filtering options like "families" or "macroareas"."""
         self.tree_prior = "yule"
         """Tree prior.  Should generally not be set manually."""
+        self.treeprior = TreePrior()
+        """Tree prior object."""
 
         # Glottolog data
         self.glottolog_loaded = False

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -29,7 +29,7 @@ import beastling.models.bsvs as bsvs
 import beastling.models.covarion as covarion
 import beastling.models.mk as mk
 
-from beastling.treepriors.base import TreePrior
+import beastling.treepriors.base as treepriors
 
 _BEAST_MAX_LENGTH = 2147483647
 GLOTTOLOG_NODE_LABEL = re.compile(
@@ -184,9 +184,7 @@ class Configuration(object):
         self.subsample_size = 0
         """Number of languages to subsample from the set defined by the dataset(s) and other filtering options like "families" or "macroareas"."""
         self.tree_prior = "yule"
-        """Tree prior.  Should generally not be set manually."""
-        self.treeprior = TreePrior()
-        """Tree prior object."""
+        """Tree prior. Can be overridden by calibrations."""
 
         # Glottolog data
         self.glottolog_loaded = False
@@ -477,11 +475,12 @@ class Configuration(object):
         # We also know what kind of tree prior we need to have –
         # instantiate_calibrations may have changed the type if tip
         # calibrations exist.
-        self.treeprior = TreePrior(self.tree_prior)
-        del self.tree_prior
-        # This is mostly for debugging reasons. We want to make sure that
-        # any future references are to the TreePrior object, not to the
-        # description string.
+        try:
+            self.treeprior = {
+                "yule": treepriors.YuleTree
+            }[self.tree_prior]()
+        except KeyError:
+            self.treeprior = TreePrior(self.tree_prior)
 
         # Now we can set the value of the ascertained attribute of each model
         # Ideally this would happen during process_models, but this is impossible

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -473,6 +473,16 @@ class Configuration(object):
         # At this point, we can tell whether or not the tree's length units
         # can be treated as arbitrary
         self.arbitrary_tree = self.sample_branch_lengths and not self.calibrations
+
+        # We also know what kind of tree prior we need to have –
+        # instantiate_calibrations may have changed the type if tip
+        # calibrations exist.
+        self.treeprior = TreePrior(self.tree_prior)
+        del self.tree_prior
+        # This is mostly for debugging reasons. We want to make sure that
+        # any future references are to the TreePrior object, not to the
+        # description string.
+
         # Now we can set the value of the ascertained attribute of each model
         # Ideally this would happen during process_models, but this is impossible
         # as set_ascertained() relies upon the value of arbitrary_tree defined above,
@@ -1103,8 +1113,6 @@ class Configuration(object):
 
                 self.messages.append("[INFO] Calibration on clade '%s' matches only one language.  Ignoring due to ambiguity.  Use 'originate(%s)' if this was supposed to be an originate calibration, or explicitly identify the single language using '%s' if this was supposed to be a tip calibration." % (clade, clade, langs[0]))
                 continue
-
-            self.treeprior = TreePrior(self.tree_prior)
 
             # Make sure this calibration point, which will induce a monophyly
             # constraint, does not conflict with the overall monophyly

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -32,6 +32,7 @@ import beastling.models.covarion as covarion
 import beastling.models.mk as mk
 
 import beastling.treepriors.base as treepriors
+from beastling.treepriors.coalescent import CoalescentTree
 
 _BEAST_MAX_LENGTH = 2147483647
 GLOTTOLOG_NODE_LABEL = re.compile(
@@ -481,7 +482,7 @@ class Configuration(object):
             "uniform": treepriors.UniformTree,
             "yule": treepriors.YuleTree,
             "birthdeath": treepriors.BirthDeathTree,
-            "coalescent": treepriors.CoalescentTree
+            "coalescent": CoalescentTree
         }[self.tree_prior.lower()]()
 
         # Now we can set the value of the ascertained attribute of each model

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -1104,6 +1104,8 @@ class Configuration(object):
                 self.messages.append("[INFO] Calibration on clade '%s' matches only one language.  Ignoring due to ambiguity.  Use 'originate(%s)' if this was supposed to be an originate calibration, or explicitly identify the single language using '%s' if this was supposed to be a tip calibration." % (clade, clade, langs[0]))
                 continue
 
+            self.treeprior = TreePrior(self.tree_prior)
+
             # Make sure this calibration point, which will induce a monophyly
             # constraint, does not conflict with the overall monophyly
             # constraints from Glottolog or a user-tree

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -475,12 +475,12 @@ class Configuration(object):
         # We also know what kind of tree prior we need to have –
         # instantiate_calibrations may have changed the type if tip
         # calibrations exist.
-        try:
-            self.treeprior = {
-                "yule": treepriors.YuleTree
-            }[self.tree_prior]()
-        except KeyError:
-            self.treeprior = TreePrior(self.tree_prior)
+        self.treeprior = {
+            "uniform": treepriors.UniformTree,
+            "yule": treepriors.YuleTree,
+            "birthdeath": treepriors.BirthDeathTree,
+            "coalescent": treepriors.CoalescentTree
+        }[self.tree_prior.lower()]()
 
         # Now we can set the value of the ascertained attribute of each model
         # Ideally this would happen during process_models, but this is impossible

--- a/beastling/configuration.py
+++ b/beastling/configuration.py
@@ -1,3 +1,5 @@
+# -*- encoding: utf-8 -*-
+
 from __future__ import division, unicode_literals
 import collections
 import importlib

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -1,0 +1,362 @@
+import xml.etree.ElementTree as ET
+from math import log, exp
+
+class TreePrior (object):
+    tree_id = "Tree.t:beastlingTree"
+
+    def add_state_nodes(self, beastxml):
+        beastxml.tree = ET.SubElement(beastxml.state, "tree", {"id":"Tree.t:beastlingTree", "name":"stateNode"})
+        beastxml.add_taxon_set(beastxml.tree, "taxa", beastxml.config.languages, define_taxa=True)
+        if beastxml.config.tree_prior in ["yule", "birthdeath"]:
+            param = ET.SubElement(beastxml.state, "parameter", {"id":"birthRate.t:beastlingTree","name":"stateNode"})
+            if beastxml.birthrate_estimate is not None:
+                param.text=str(beastxml.birthrate_estimate)
+            else:
+                param.text="1.0"
+            if beastxml.config.tree_prior in ["birthdeath"]:
+                ET.SubElement(beastxml.state, "parameter",
+                              {"id": "deathRate.t:beastlingTree",
+                               "name": "stateNode"}).text = "0.5"
+                ET.SubElement(beastxml.state, "parameter",
+                              {"id": "sampling.t:beastlingTree",
+                               "name": "stateNode"}).text = "0.2"
+
+        elif beastxml.config.tree_prior == "coalescent":
+            param = ET.SubElement(beastxml.state, "parameter", {"id":"popSize.t:beastlingTree","name":"stateNode"})
+            param.text="1.0"
+        if beastxml.config.tip_calibrations:
+            beastxml.add_tip_heights()
+
+    def estimate_height(self, config):
+        birthrate_estimates = []
+        for cal in config.config.calibrations.values():
+            if len(cal.langs) == 1 or cal.dist not in ("normal", "lognormal"):
+                continue
+            # Find the midpoint of this cal
+            mid = cal.mean()
+            # Find the Yule birthrate which results in an expected height for
+            # a tree of this many taxa which equals the midpoint of the
+            # calibration.
+            # The expected height of a Yule tree with n taxa and
+            # birthrate λ is 1/λ * (Hn - 1), where Hn is the nth
+            # harmonic number.  Hn can be asymptotically approximated
+            # by Hn = log(n) + 0.5772156649. So λ = (Hn - 1) / h.
+            birthrate = (log(len(cal.langs)) + 0.5772156649 - 1) / mid
+            birthrate_estimates.append(birthrate)
+        # If there were no calibrations that could be used, return a non-esitmate
+        if not birthrate_estimates:
+            config.birthrate_estimate = None
+            config.treeheight_estimate = None
+            return
+        # Find the mean birthrate estimate
+        config.birthrate_estimate = round(sum(birthrate_estimates) / len(birthrate_estimates), 4)
+        # Find the expected height of a tree with this birthrate
+        config.treeheight_estimate = round((1.0/config.birthrate_estimate)*(log(len(config.config.languages)) + 0.5772156649 - 1), 4)
+
+    def add_init(self, beastxml):
+        """
+        Add the <init> element for the tree.
+        """
+        # If a starting tree is specified, use it...
+        if beastxml.config.starting_tree:
+            beastxml.init = ET.SubElement(beastxml.run, "init", {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "spec":"beast.util.TreeParser","IsLabelledNewick":"true", "newick":beastxml.config.starting_tree})
+        # ...if not, use the simplest random tree initialiser possible
+        else:
+            # If we have non-trivial monophyly constraints, use ConstrainedRandomTree
+            if beastxml.config.monophyly and len(beastxml.config.languages) > 2:
+                self.add_constrainedrandomtree_init(beastxml)
+            # If we have hard-bound calibrations, use SimpleRandomTree
+            elif any([c.dist == "uniform" for c in beastxml.config.calibrations.values()]):
+                self.add_simplerandomtree_init(beastxml)
+            # Otherwise, just use RandomTree
+            else:
+                self.add_randomtree_init(beastxml)
+
+    def add_randomtree_init(self, beastxml):
+        attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.RandomTree"}
+        if beastxml.birthrate_estimate is not None:
+            attribs["rootHeight"] = str(beastxml.treeheight_estimate)
+        beastxml.init = ET.SubElement(beastxml.run, "init", attribs)
+        popmod = ET.SubElement(beastxml.init, "populationModel", {"spec":"ConstantPopulation"})
+        ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})
+
+    def add_simplerandomtree_init(self, beastxml):
+        attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.SimpleRandomTree"}
+        if beastxml.birthrate_estimate is not None:
+            attribs["rootHeight"] = str(beastxml.treeheight_estimate)
+        beastxml.init = ET.SubElement(beastxml.run, "init", attribs)
+
+    def add_constrainedrandomtree_init(self, beastxml):
+        attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.ConstrainedRandomTree", "constraints":"@constraints"}
+        if beastxml.birthrate_estimate is not None:
+            attribs["rootHeight"] = str(beastxml.treeheight_estimate)
+        beastxml.init = ET.SubElement(beastxml.run, "init", attribs)
+        popmod = ET.SubElement(beastxml.init, "populationModel", {"spec":"ConstantPopulation"})
+        ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})
+
+    def add_prior(self, beastxml):
+        if beastxml.config.tree_prior.lower() == "yule":
+            self.add_yule_tree_prior(beastxml)
+        elif beastxml.config.tree_prior.lower() == "birthdeath":
+            self.add_birthdeath_tree_prior(beastxm)
+        elif beastxml.config.tree_prior.lower() == "coalescent":
+            self.add_coalescent_tree_prior(beastxml)
+        elif beastxml.config.tree_prior.lower() == "uniform":
+            pass
+        else:
+            raise ValueError("Tree prior {:} is unknown.".format(
+                beastxml.config.tree_prior.lower()))
+
+    def add_birthdeath_tree_prior(self, beastxml):
+        """Add a (calibrated) birth-death tree prior."""
+        # Tree prior
+
+        attribs = {}
+        attribs["id"] = "BirthDeathModel.t:beastlingTree"
+        attribs["tree"] = "@Tree.t:beastlingTree"
+        attribs["spec"] = "beast.evolution.speciation.BirthDeathGernhard08Model"
+        attribs["birthRate"] = "@birthRate.t:beastlingTree"
+        attribs["relativeDeathRate"] = "@deathRate.t:beastlingTree"
+        attribs["sampleProbability"] = "@sampling.t:beastlingTree"
+        attribs["type"] = "restricted"
+
+        # Birth rate prior
+        attribs = {}
+        attribs["id"] = "BirthRatePrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@birthRate.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform",
+                                {"id": "Uniform.0",
+                                 "name": "distr",
+                                 "upper": "Infinity"})
+
+        # Relative death rate prior
+        attribs = {}
+        attribs["id"] = "relativeDeathRatePrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@deathRate.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform",
+                                {"id": "Uniform.1",
+                                 "name": "distr",
+                                 "upper": "Infinity"})
+
+        # Sample probability prior
+        attribs = {}
+        attribs["id"] = "samplingPrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@sampling.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform",
+                                {"id": "Uniform.3",
+                                 "name": "distr",
+                                 "lower": "0",
+                                 "upper": "1"})
+
+
+    def add_yule_tree_prior(self, beastxml):
+        """
+        Add Yule birth-process tree prior.
+        """
+        # Tree prior
+        ## Decide whether to use the standard Yule or the fancy calibrated one
+        if len(beastxml.config.calibrations) == 1:
+            yule = "calibrated"
+        elif len(beastxml.config.calibrations) == 2:
+            # Two calibrations can be handled by the calibrated Yule if they
+            # are nested
+            langs1, langs2 = [c.langs for c in beastxml.config.calibrations.values()]
+            if len(set(langs1) & set(langs2)) in (len(langs1), len(langs2)):
+                yule = "calibrated"
+            else:
+                yule = "standard"
+        else:
+            yule = "standard"
+
+        attribs = {}
+        attribs["id"] = "YuleModel.t:beastlingTree"
+        attribs["tree"] = "@Tree.t:beastlingTree"
+        if yule == "standard":
+            attribs["spec"] = "beast.evolution.speciation.YuleModel"
+            attribs["birthDiffRate"] = "@birthRate.t:beastlingTree"
+            if "root" in beastxml.config.calibrations:
+                attribs["conditionalOnRoot"] = "true"
+        elif yule == "calibrated":
+            attribs["spec"] = "beast.evolution.speciation.CalibratedYuleModel"
+            attribs["birthRate"] = "@birthRate.t:beastlingTree"
+        ET.SubElement(beastxml.prior, "distribution", attribs)
+
+        # Birth rate prior
+        attribs = {}
+        attribs["id"] = "YuleBirthRatePrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@birthRate.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform", {"id":"Uniform.0","name":"distr","upper":"Infinity"})
+
+    def add_coalescent_tree_prior(self, beastxml):
+
+        coalescent = ET.SubElement(beastxml.prior, "distribution", {
+            "id": "Coalescent.t:beastlingTree",
+            "spec": "Coalescent",
+            })
+        popmod = ET.SubElement(coalescent, "populationModel", {
+            "id": "ConstantPopulation:beastlingTree",
+            "spec": "ConstantPopulation",
+            })
+        ET.SubElement(popmod, "parameter", {
+            "idref": "popSize.t:beastlingTree",
+            "name": "popSize",
+            })
+        ET.SubElement(coalescent, "treeIntervals", {
+            "id": "TreeIntervals",
+            "spec": "TreeIntervals",
+            "tree": "@Tree.t:beastlingTree",
+            })
+
+    def add_operators(self, beastxml):
+        """
+        Add all <operator>s which act on the tree topology and branch lengths.
+        """
+        """
+        Add all <operator>s which act on the tree topology and branch lengths.
+        """
+        # Tree operators
+        # Operators which affect the tree must respect the sample_topology and
+        # sample_branch_length options.
+        if self.config.sample_topology:
+            ## Tree topology operators
+            ET.SubElement(self.run, "operator", {"id":"SubtreeSlide.t:beastlingTree","spec":"SubtreeSlide","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"15.0"})
+            ET.SubElement(self.run, "operator", {"id":"narrow.t:beastlingTree","spec":"Exchange","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"15.0"})
+            ET.SubElement(self.run, "operator", {"id":"wide.t:beastlingTree","isNarrow":"false","spec":"Exchange","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"3.0"})
+            ET.SubElement(self.run, "operator", {"id":"WilsonBalding.t:beastlingTree","spec":"WilsonBalding","tree":"@Tree.t:beastlingTree","markclades":"true","weight":"3.0"})
+        if self.config.sample_branch_lengths:
+            ## Branch length operators
+            ET.SubElement(self.run, "operator", {"id":"UniformOperator.t:beastlingTree","spec":"Uniform","tree":"@Tree.t:beastlingTree","weight":"30.0"})
+            ET.SubElement(self.run, "operator", {"id":"treeScaler.t:beastlingTree","scaleFactor":"0.5","spec":"ScaleOperator","tree":"@Tree.t:beastlingTree","weight":"3.0"})
+            ET.SubElement(self.run, "operator", {"id":"treeRootScaler.t:beastlingTree","scaleFactor":"0.5","spec":"ScaleOperator","tree":"@Tree.t:beastlingTree","rootOnly":"true","weight":"3.0"})
+            ## Up/down operator which scales tree height
+            if self.config.tree_prior in ["yule", "birthdeath"]:
+                updown = ET.SubElement(self.run, "operator", {"id":"UpDown","spec":"UpDownOperator","scaleFactor":"0.5", "weight":"3.0"})
+                ET.SubElement(updown, "tree", {"idref":"Tree.t:beastlingTree", "name":"up"})
+                ET.SubElement(updown, "parameter", {"idref":"birthRate.t:beastlingTree", "name":"down"})
+                ### Include clock rates in up/down only if calibrations are given
+                if self.config.calibrations:
+                    for clock in self.config.clocks:
+                        if clock.estimate_rate:
+                            ET.SubElement(updown, "parameter", {"idref":clock.mean_rate_id, "name":"down"})
+
+        if self.config.tree_prior in ["yule", "birthdeath"]:
+            # Birth rate scaler
+            # Birth rate is *always* scaled.
+            ET.SubElement(self.run, "operator", {"id":"YuleBirthRateScaler.t:beastlingTree","spec":"ScaleOperator","parameter":"@birthRate.t:beastlingTree", "scaleFactor":"0.5", "weight":"3.0"})
+        elif self.config.tree_prior == "coalescent":
+            ET.SubElement(self.run, "operator", {"id":"PopulationSizeScaler.t:beastlingTree","spec":"ScaleOperator","parameter":"@popSize.t:beastlingTree", "scaleFactor":"0.5", "weight":"3.0"})
+
+        if self.config.tree_prior in ["birthdeath"]:
+            ET.SubElement(self.run, "operator",
+                          {"id": "SamplingScaler.t:beastlingTree",
+                           "spec": "ScaleOperator",
+                           "parameter": "@sampling.t:beastlingTree",
+                           "scaleFactor": "0.8",
+                           "weight": "1.0"})
+            ET.SubElement(self.run, "operator",
+                          {"id": "DeathRateScaler.t:beastlingTree",
+                           "spec": "ScaleOperator",
+                           "parameter": "@deathRate.t:beastlingTree",
+                           "scaleFactor": "0.5",
+                           "weight": "3.0"})
+ 
+        # Add a Tip Date scaling operator if required
+        if self.config.tip_calibrations and self.config.sample_branch_lengths:
+            # Get a list of taxa with non-point tip cals
+            tip_taxa = [next(cal.langs.__iter__()) for cal in self.config.tip_calibrations.values() if cal.dist != "point"]
+            for taxon in tip_taxa:
+                tiprandomwalker = ET.SubElement(self.run, "operator",
+                    {"id": "TipDatesandomWalker:%s" % taxon,
+                     "spec": "TipDatesRandomWalker",
+                     "windowSize": "1",
+                     "tree": "@Tree.t:beastlingTree",
+                     "weight": "3.0",
+                     })
+                self.add_taxon_set(tiprandomwalker, taxon, (taxon,))
+
+    def add_logging(self, beastxml, tracer_logger):
+        if beastxml.config.tree_prior in ["yule", "birthdeath"]:
+            ET.SubElement(tracer_logger,"log",{"idref":"birthRate.t:beastlingTree"})
+            if beastxml.config.tree_prior in ["birthdeath"]:
+                ET.SubElement(tracer_logger, "log",
+                                {"idref": "deathRate.t:beastlingTree"})
+                ET.SubElement(tracer_logger, "log",
+                                {"idref": "sampling.t:beastlingTree"})
+        elif beastxml.config.tree_prior == "coalescent":
+            ET.SubElement(tracer_logger,"log",{"idref":"popSize.t:beastlingTree"})
+
+        if beastxml.config.tree_prior == "yule":
+            ET.SubElement(tracer_logger,"log",{"idref":"birthRate.t:beastlingTree"})
+        elif beastxml.config.tree_prior == "coalescent":
+            ET.SubElement(tracer_logger,"log",{"idref":"popSize.t:beastlingTree"})
+
+        # Log tree height
+        if not beastxml.config.tree_logging_pointless:
+            ET.SubElement(tracer_logger,"log",{
+                "id":"treeStats",
+                "spec":"beast.evolution.tree.TreeStatLogger",
+                "tree":"@Tree.t:beastlingTree"})
+
+        # Fine-grained logging
+        if beastxml.config.log_fine_probs:
+            ET.SubElement(tracer_logger,"log",{"idref":"YuleModel.t:beastlingTree"})
+            ET.SubElement(tracer_logger,"log",{"idref":"YuleBirthRatePrior.t:beastlingTree"})
+
+    def add_operators(self, beastxml):
+        """
+        Add all <operator>s which act on the tree topology and branch lengths.
+        """
+        # Tree operators
+        # Operators which affect the tree must respect the sample_topology and
+        # sample_branch_length options.
+        if beastxml.config.sample_topology:
+            ## Tree topology operators
+            ET.SubElement(beastxml.run, "operator", {"id":"SubtreeSlide.t:beastlingTree","spec":"SubtreeSlide","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"15.0"})
+            ET.SubElement(beastxml.run, "operator", {"id":"narrow.t:beastlingTree","spec":"Exchange","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"15.0"})
+            ET.SubElement(beastxml.run, "operator", {"id":"wide.t:beastlingTree","isNarrow":"false","spec":"Exchange","tree":"@Tree.t:beastlingTree","markclades":"true", "weight":"3.0"})
+            ET.SubElement(beastxml.run, "operator", {"id":"WilsonBalding.t:beastlingTree","spec":"WilsonBalding","tree":"@Tree.t:beastlingTree","markclades":"true","weight":"3.0"})
+        if beastxml.config.sample_branch_lengths:
+            ## Branch length operators
+            ET.SubElement(beastxml.run, "operator", {"id":"UniformOperator.t:beastlingTree","spec":"Uniform","tree":"@Tree.t:beastlingTree","weight":"30.0"})
+            ET.SubElement(beastxml.run, "operator", {"id":"treeScaler.t:beastlingTree","scaleFactor":"0.5","spec":"ScaleOperator","tree":"@Tree.t:beastlingTree","weight":"3.0"})
+            ET.SubElement(beastxml.run, "operator", {"id":"treeRootScaler.t:beastlingTree","scaleFactor":"0.5","spec":"ScaleOperator","tree":"@Tree.t:beastlingTree","rootOnly":"true","weight":"3.0"})
+            ## Up/down operator which scales tree height
+            if beastxml.config.tree_prior == "yule":
+                updown = ET.SubElement(beastxml.run, "operator", {"id":"UpDown","spec":"UpDownOperator","scaleFactor":"0.5", "weight":"3.0"})
+                ET.SubElement(updown, "tree", {"idref":"Tree.t:beastlingTree", "name":"up"})
+                ET.SubElement(updown, "parameter", {"idref":"birthRate.t:beastlingTree", "name":"down"})
+                ### Include clock rates in up/down only if calibrations are given
+                if beastxml.config.calibrations:
+                    for clock in beastxml.config.clocks:
+                        if clock.estimate_rate:
+                            ET.SubElement(updown, "parameter", {"idref":clock.mean_rate_id, "name":"down"})
+
+        if beastxml.config.tree_prior == "yule":
+            # Birth rate scaler
+            # Birth rate is *always* scaled.
+            ET.SubElement(beastxml.run, "operator", {"id":"YuleBirthRateScaler.t:beastlingTree","spec":"ScaleOperator","parameter":"@birthRate.t:beastlingTree", "scaleFactor":"0.5", "weight":"3.0"})
+        elif beastxml.config.tree_prior == "coalescent":
+            ET.SubElement(beastxml.run, "operator", {"id":"PopulationSizeScaler.t:beastlingTree","spec":"ScaleOperator","parameter":"@popSize.t:beastlingTree", "scaleFactor":"0.5", "weight":"3.0"})
+
+        # Add a Tip Date scaling operator if required
+        if beastxml.config.tip_calibrations and beastxml.config.sample_branch_lengths:
+            # Get a list of taxa with non-point tip cals
+            tip_taxa = [next(cal.langs.__iter__()) for cal in beastxml.config.tip_calibrations.values() if cal.dist != "point"]
+            for taxon in tip_taxa:
+                tiprandomwalker = ET.SubElement(beastxml.run, "operator",
+                    {"id": "TipDatesandomWalker:%s" % taxon,
+                    "spec": "TipDatesRandomWalker",
+                    "windowSize": "1",
+                    "tree": "@Tree.t:beastlingTree",
+                    "weight": "3.0",
+                    })
+                beastxml.add_taxon_set(tiprandomwalker, taxon, (taxon,))
+

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -385,3 +385,15 @@ class TreePrior (object):
 class YuleTree (TreePrior):
     def __init__(self):
         super(YuleTree, self).__init__("yule")
+
+class BirthDeathTree (TreePrior):
+    def __init__(self):
+        super(BirthDeathTree, self).__init__("birthdeath")
+
+class CoalescentTree (TreePrior):
+    def __init__(self):
+        super(CoalescentTree, self).__init__("coalescent")
+
+class UniformTree (TreePrior):
+    def __init__(self):
+        super(UniformTree, self).__init__("uniform")

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -3,9 +3,10 @@ from math import log, exp
 
 class TreePrior (object):
     tree_id = "Tree.t:beastlingTree"
+    type = None
 
-    def __init__(self, type='yule'):
-        self.type = type.lower()
+    def __init__(self):
+        pass
 
     def add_state_nodes(self, beastxml):
         """
@@ -117,125 +118,8 @@ class TreePrior (object):
         ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})
 
     def add_prior(self, beastxml):
-        if self.type == "yule":
-            self.add_yule_tree_prior(beastxml)
-        elif self.type == "birthdeath":
-            self.add_birthdeath_tree_prior(beastxm)
-        elif self.type == "coalescent":
-            self.add_coalescent_tree_prior(beastxml)
-        elif self.type == "uniform":
-            pass
-        else:
-            raise ValueError("Tree prior {:} is unknown.".format(
-                self.type))
-
-    def add_birthdeath_tree_prior(self, beastxml):
-        """Add a (calibrated) birth-death tree prior."""
-        # Tree prior
-
-        attribs = {}
-        attribs["id"] = "BirthDeathModel.t:beastlingTree"
-        attribs["tree"] = "@Tree.t:beastlingTree"
-        attribs["spec"] = "beast.evolution.speciation.BirthDeathGernhard08Model"
-        attribs["birthRate"] = "@birthRate.t:beastlingTree"
-        attribs["relativeDeathRate"] = "@deathRate.t:beastlingTree"
-        attribs["sampleProbability"] = "@sampling.t:beastlingTree"
-        attribs["type"] = "restricted"
-
-        # Birth rate prior
-        attribs = {}
-        attribs["id"] = "BirthRatePrior.t:beastlingTree"
-        attribs["name"] = "distribution"
-        attribs["x"] = "@birthRate.t:beastlingTree"
-        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
-        uniform = ET.SubElement(sub_prior, "Uniform",
-                                {"id": "Uniform.0",
-                                 "name": "distr",
-                                 "upper": "Infinity"})
-
-        # Relative death rate prior
-        attribs = {}
-        attribs["id"] = "relativeDeathRatePrior.t:beastlingTree"
-        attribs["name"] = "distribution"
-        attribs["x"] = "@deathRate.t:beastlingTree"
-        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
-        uniform = ET.SubElement(sub_prior, "Uniform",
-                                {"id": "Uniform.1",
-                                 "name": "distr",
-                                 "upper": "Infinity"})
-
-        # Sample probability prior
-        attribs = {}
-        attribs["id"] = "samplingPrior.t:beastlingTree"
-        attribs["name"] = "distribution"
-        attribs["x"] = "@sampling.t:beastlingTree"
-        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
-        uniform = ET.SubElement(sub_prior, "Uniform",
-                                {"id": "Uniform.3",
-                                 "name": "distr",
-                                 "lower": "0",
-                                 "upper": "1"})
-
-
-    def add_yule_tree_prior(self, beastxml):
-        """
-        Add Yule birth-process tree prior.
-        """
-        # Tree prior
-        ## Decide whether to use the standard Yule or the fancy calibrated one
-        if len(beastxml.config.calibrations) == 1:
-            yule = "calibrated"
-        elif len(beastxml.config.calibrations) == 2:
-            # Two calibrations can be handled by the calibrated Yule if they
-            # are nested
-            langs1, langs2 = [c.langs for c in beastxml.config.calibrations.values()]
-            if len(set(langs1) & set(langs2)) in (len(langs1), len(langs2)):
-                yule = "calibrated"
-            else:
-                yule = "standard"
-        else:
-            yule = "standard"
-
-        attribs = {}
-        attribs["id"] = "YuleModel.t:beastlingTree"
-        attribs["tree"] = "@Tree.t:beastlingTree"
-        if yule == "standard":
-            attribs["spec"] = "beast.evolution.speciation.YuleModel"
-            attribs["birthDiffRate"] = "@birthRate.t:beastlingTree"
-            if "root" in beastxml.config.calibrations:
-                attribs["conditionalOnRoot"] = "true"
-        elif yule == "calibrated":
-            attribs["spec"] = "beast.evolution.speciation.CalibratedYuleModel"
-            attribs["birthRate"] = "@birthRate.t:beastlingTree"
-        ET.SubElement(beastxml.prior, "distribution", attribs)
-
-        # Birth rate prior
-        attribs = {}
-        attribs["id"] = "YuleBirthRatePrior.t:beastlingTree"
-        attribs["name"] = "distribution"
-        attribs["x"] = "@birthRate.t:beastlingTree"
-        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
-        uniform = ET.SubElement(sub_prior, "Uniform", {"id":"Uniform.0","name":"distr","upper":"Infinity"})
-
-    def add_coalescent_tree_prior(self, beastxml):
-
-        coalescent = ET.SubElement(beastxml.prior, "distribution", {
-            "id": "Coalescent.t:beastlingTree",
-            "spec": "Coalescent",
-            })
-        popmod = ET.SubElement(coalescent, "populationModel", {
-            "id": "ConstantPopulation:beastlingTree",
-            "spec": "ConstantPopulation",
-            })
-        ET.SubElement(popmod, "parameter", {
-            "idref": "popSize.t:beastlingTree",
-            "name": "popSize",
-            })
-        ET.SubElement(coalescent, "treeIntervals", {
-            "id": "TreeIntervals",
-            "spec": "TreeIntervals",
-            "tree": "@Tree.t:beastlingTree",
-            })
+        raise ValueError("Tree prior {:} is unknown.".format(
+            self.type))
 
     def add_operators(self, beastxml):
         """
@@ -384,16 +268,138 @@ class TreePrior (object):
 
 class YuleTree (TreePrior):
     def __init__(self):
-        super(YuleTree, self).__init__("yule")
+        super(YuleTree, self).__init__()
+        self.type = "yule"
+
+    def add_prior(self, beastxml):
+        """
+        Add Yule birth-process tree prior.
+        """
+        # Tree prior
+        ## Decide whether to use the standard Yule or the fancy calibrated one
+        if len(beastxml.config.calibrations) == 1:
+            yule = "calibrated"
+        elif len(beastxml.config.calibrations) == 2:
+            # Two calibrations can be handled by the calibrated Yule if they
+            # are nested
+            langs1, langs2 = [c.langs for c in beastxml.config.calibrations.values()]
+            if len(set(langs1) & set(langs2)) in (len(langs1), len(langs2)):
+                yule = "calibrated"
+            else:
+                yule = "standard"
+        else:
+            yule = "standard"
+
+        attribs = {}
+        attribs["id"] = "YuleModel.t:beastlingTree"
+        attribs["tree"] = "@Tree.t:beastlingTree"
+        if yule == "standard":
+            attribs["spec"] = "beast.evolution.speciation.YuleModel"
+            attribs["birthDiffRate"] = "@birthRate.t:beastlingTree"
+            if "root" in beastxml.config.calibrations:
+                attribs["conditionalOnRoot"] = "true"
+        elif yule == "calibrated":
+            attribs["spec"] = "beast.evolution.speciation.CalibratedYuleModel"
+            attribs["birthRate"] = "@birthRate.t:beastlingTree"
+        ET.SubElement(beastxml.prior, "distribution", attribs)
+
+        # Birth rate prior
+        attribs = {}
+        attribs["id"] = "YuleBirthRatePrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@birthRate.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform", {"id":"Uniform.0","name":"distr","upper":"Infinity"})
+
 
 class BirthDeathTree (TreePrior):
     def __init__(self):
-        super(BirthDeathTree, self).__init__("birthdeath")
+        super(BirthDeathTree, self).__init__()
+        self.type = "birthdeath"
+
+    def add_prior(self, beastxml):
+        """Add a (calibrated) birth-death tree prior."""
+        # Tree prior
+
+        attribs = {}
+        attribs["id"] = "BirthDeathModel.t:beastlingTree"
+        attribs["tree"] = "@Tree.t:beastlingTree"
+        attribs["spec"] = "beast.evolution.speciation.BirthDeathGernhard08Model"
+        attribs["birthRate"] = "@birthRate.t:beastlingTree"
+        attribs["relativeDeathRate"] = "@deathRate.t:beastlingTree"
+        attribs["sampleProbability"] = "@sampling.t:beastlingTree"
+        attribs["type"] = "restricted"
+
+        # Birth rate prior
+        attribs = {}
+        attribs["id"] = "BirthRatePrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@birthRate.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform",
+                                {"id": "Uniform.0",
+                                 "name": "distr",
+                                 "upper": "Infinity"})
+
+        # Relative death rate prior
+        attribs = {}
+        attribs["id"] = "relativeDeathRatePrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@deathRate.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform",
+                                {"id": "Uniform.1",
+                                 "name": "distr",
+                                 "upper": "Infinity"})
+
+        # Sample probability prior
+        attribs = {}
+        attribs["id"] = "samplingPrior.t:beastlingTree"
+        attribs["name"] = "distribution"
+        attribs["x"] = "@sampling.t:beastlingTree"
+        sub_prior = ET.SubElement(beastxml.prior, "prior", attribs)
+        uniform = ET.SubElement(sub_prior, "Uniform",
+                                {"id": "Uniform.3",
+                                 "name": "distr",
+                                 "lower": "0",
+                                 "upper": "1"})
 
 class CoalescentTree (TreePrior):
     def __init__(self):
-        super(CoalescentTree, self).__init__("coalescent")
+        super(CoalescentTree, self).__init__()
+        self.type = "coalescent"
+
+    def add_prior(self, beastxml):
+        """Add a Yule tree prior."""
+        coalescent = ET.SubElement(beastxml.prior, "distribution", {
+            "id": "Coalescent.t:beastlingTree",
+            "spec": "Coalescent",
+            })
+        popmod = ET.SubElement(coalescent, "populationModel", {
+            "id": "ConstantPopulation:beastlingTree",
+            "spec": "ConstantPopulation",
+            })
+        ET.SubElement(popmod, "parameter", {
+            "idref": "popSize.t:beastlingTree",
+            "name": "popSize",
+            })
+        ET.SubElement(coalescent, "treeIntervals", {
+            "id": "TreeIntervals",
+            "spec": "TreeIntervals",
+            "tree": "@Tree.t:beastlingTree",
+            })
+
 
 class UniformTree (TreePrior):
     def __init__(self):
-        super(UniformTree, self).__init__("uniform")
+        super(UniformTree, self).__init__()
+        self.type = "uniform"
+
+    def add_prior(self, beastxml):
+        """Add nothing.
+
+        For a uniform tree prior, all trees have the same probability, so the
+        tree prior can remain implicit and unspecified.
+
+        """
+        pass

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 import xml.etree.ElementTree as ET
 from math import log, exp
 

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -374,31 +374,6 @@ class BirthDeathTree (TreePrior):
                                  "lower": "0",
                                  "upper": "1"})
 
-class CoalescentTree (TreePrior):
-    def __init__(self):
-        super(CoalescentTree, self).__init__()
-        self.type = "coalescent"
-
-    def add_prior(self, beastxml):
-        """Add a Yule tree prior."""
-        coalescent = ET.SubElement(beastxml.prior, "distribution", {
-            "id": "Coalescent.t:beastlingTree",
-            "spec": "Coalescent",
-            })
-        popmod = ET.SubElement(coalescent, "populationModel", {
-            "id": "ConstantPopulation:beastlingTree",
-            "spec": "ConstantPopulation",
-            })
-        ET.SubElement(popmod, "parameter", {
-            "idref": "popSize.t:beastlingTree",
-            "name": "popSize",
-            })
-        ET.SubElement(coalescent, "treeIntervals", {
-            "id": "TreeIntervals",
-            "spec": "TreeIntervals",
-            "tree": "@Tree.t:beastlingTree",
-            })
-
 
 class UniformTree (TreePrior):
     def __init__(self):

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -382,3 +382,6 @@ class TreePrior (object):
                     })
                 beastxml.add_taxon_set(tiprandomwalker, taxon, (taxon,))
 
+class YuleTree (TreePrior):
+    def __init__(self):
+        super(YuleTree, self).__init__("yule")

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -17,8 +17,8 @@ class TreePrior (object):
         ET.SubElement(self.tree, "taxonset", {"idref": "taxa"})
         if self.type in ["yule", "birthdeath"]:
             param = ET.SubElement(state, "parameter", {"id":"birthRate.t:beastlingTree","name":"stateNode"})
-            if beastxml.birthrate_estimate is not None:
-                param.text=str(beastxml.birthrate_estimate)
+            if self.birthrate_estimate is not None:
+                param.text=str(self.birthrate_estimate)
             else:
                 param.text="1.0"
             if self.type in ["birthdeath"]:
@@ -53,13 +53,15 @@ class TreePrior (object):
             birthrate_estimates.append(birthrate)
         # If there were no calibrations that could be used, return a non-esitmate
         if not birthrate_estimates:
-            config.birthrate_estimate = None
-            config.treeheight_estimate = None
+            self.birthrate_estimate = None
+            self.treeheight_estimate = None
             return
         # Find the mean birthrate estimate
-        config.birthrate_estimate = round(sum(birthrate_estimates) / len(birthrate_estimates), 4)
+        self.birthrate_estimate = round(sum(birthrate_estimates) / len(birthrate_estimates), 4)
         # Find the expected height of a tree with this birthrate
-        config.treeheight_estimate = round((1.0/config.birthrate_estimate)*(log(len(config.config.languages)) + 0.5772156649 - 1), 4)
+        self.treeheight_estimate = round((1.0 / self.birthrate_estimate)
+                                         * (log(len(config.config.languages))
+                                            + 0.5772156649 - 1), 4)
 
     def add_tip_heights(self, tip_calibrations):
         """Add the <trait> element for tip dates to self.treeheight
@@ -105,22 +107,22 @@ class TreePrior (object):
 
     def add_randomtree_init(self, beastxml):
         attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.RandomTree"}
-        if beastxml.birthrate_estimate is not None:
-            attribs["rootHeight"] = str(beastxml.treeheight_estimate)
+        if self.birthrate_estimate is not None:
+            attribs["rootHeight"] = str(self.treeheight_estimate)
         beastxml.init = ET.SubElement(beastxml.run, "init", attribs)
         popmod = ET.SubElement(beastxml.init, "populationModel", {"spec":"ConstantPopulation"})
         ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})
 
     def add_simplerandomtree_init(self, beastxml):
         attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.SimpleRandomTree"}
-        if beastxml.birthrate_estimate is not None:
-            attribs["rootHeight"] = str(beastxml.treeheight_estimate)
+        if self.birthrate_estimate is not None:
+            attribs["rootHeight"] = str(self.treeheight_estimate)
         beastxml.init = ET.SubElement(beastxml.run, "init", attribs)
 
     def add_constrainedrandomtree_init(self, beastxml):
         attribs = {"estimate":"false", "id":"startingTree", "initial":"@Tree.t:beastlingTree", "taxonset":"@taxa", "spec":"beast.evolution.tree.ConstrainedRandomTree", "constraints":"@constraints"}
-        if beastxml.birthrate_estimate is not None:
-            attribs["rootHeight"] = str(beastxml.treeheight_estimate)
+        if self.birthrate_estimate is not None:
+            attribs["rootHeight"] = str(self.treeheight_estimate)
         beastxml.init = ET.SubElement(beastxml.run, "init", attribs)
         popmod = ET.SubElement(beastxml.init, "populationModel", {"spec":"ConstantPopulation"})
         ET.SubElement(popmod, "popSize", {"spec":"parameter.RealParameter","value":"1"})

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -10,7 +10,7 @@ class TreePrior (object):
         """
         state = beastxml.state
         self.tree = ET.SubElement(state, "tree", {"id": self.tree_id, "name": "stateNode"})
-        beastxml.add_taxon_set(self.tree, "taxa", beastxml.config.languages, define_taxa=True)
+        ET.SubElement(self.tree, "taxa", {"idref": "taxa"})
         if beastxml.config.tree_prior in ["yule", "birthdeath"]:
             param = ET.SubElement(state, "parameter", {"id":"birthRate.t:beastlingTree","name":"stateNode"})
             if beastxml.birthrate_estimate is not None:

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -4,13 +4,16 @@ from math import log, exp
 class TreePrior (object):
     tree_id = "Tree.t:beastlingTree"
 
+    def __init__(self, type='yule'):
+        self.type = type
+
     def add_state_nodes(self, beastxml):
         """
         Add tree-related <state> sub-elements.
         """
         state = beastxml.state
         self.tree = ET.SubElement(state, "tree", {"id": self.tree_id, "name": "stateNode"})
-        ET.SubElement(self.tree, "taxa", {"idref": "taxa"})
+        ET.SubElement(self.tree, "taxonset", {"idref": "taxa"})
         if beastxml.config.tree_prior in ["yule", "birthdeath"]:
             param = ET.SubElement(state, "parameter", {"id":"birthRate.t:beastlingTree","name":"stateNode"})
             if beastxml.birthrate_estimate is not None:

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -33,7 +33,7 @@ class TreePrior (object):
             param = ET.SubElement(beastxml.state, "parameter", {"id":"popSize.t:beastlingTree","name":"stateNode"})
             param.text="1.0"
         if beastxml.config.tip_calibrations:
-            beastxml.add_tip_heights()
+            self.add_tip_heights(beastxml)
 
     def estimate_height(self, config):
         birthrate_estimates = []

--- a/beastling/treepriors/base.py
+++ b/beastling/treepriors/base.py
@@ -33,7 +33,7 @@ class TreePrior (object):
             param = ET.SubElement(beastxml.state, "parameter", {"id":"popSize.t:beastlingTree","name":"stateNode"})
             param.text="1.0"
         if beastxml.config.tip_calibrations:
-            self.add_tip_heights(beastxml)
+            self.add_tip_heights(beastxml.config.tip_calibrations)
 
     def estimate_height(self, config):
         birthrate_estimates = []
@@ -61,9 +61,18 @@ class TreePrior (object):
         # Find the expected height of a tree with this birthrate
         config.treeheight_estimate = round((1.0/config.birthrate_estimate)*(log(len(config.config.languages)) + 0.5772156649 - 1), 4)
 
-    def add_tip_heights(self, beastxml):
+    def add_tip_heights(self, tip_calibrations):
+        """Add the <trait> element for tip dates to self.treeheight
+
+        Take the tip calibrations passed and add a tree <trait> which
+        represents the ages of the tips, in arbitrary (but consistent) time
+        units befor a reference date, eg. BP.
+
+        """
+        if not tip_calibrations:
+            return
         string_bits = []
-        for cal in beastxml.config.tip_calibrations.values():
+        for cal in tip_calibrations.values():
             initial_height = cal.mean()
             string_bits.append("{:s} = {:}".format(next(cal.langs.__iter__()), initial_height))
         trait_string = ",\n".join(string_bits)
@@ -74,7 +83,6 @@ class TreePrior (object):
                        "taxa": "@taxa",
                        "traitname": "date-backward"})
         datetrait.text = trait_string
-
 
     def add_init(self, beastxml):
         """

--- a/beastling/treepriors/coalescent.py
+++ b/beastling/treepriors/coalescent.py
@@ -1,0 +1,4 @@
+from .base import Tree
+
+class CoalescentTreePrior(TreePrior):
+    pass

--- a/beastling/treepriors/coalescent.py
+++ b/beastling/treepriors/coalescent.py
@@ -1,4 +1,28 @@
-from .base import Tree
+import xml.etree.ElementTree as ET
+from .base import TreePrior
 
-class CoalescentTreePrior(TreePrior):
-    pass
+class CoalescentTree (TreePrior):
+    def __init__(self):
+        super(CoalescentTree, self).__init__()
+        self.type = "coalescent"
+
+    def add_prior(self, beastxml):
+        """Add a Yule tree prior."""
+        coalescent = ET.SubElement(beastxml.prior, "distribution", {
+            "id": "Coalescent.t:beastlingTree",
+            "spec": "Coalescent",
+            })
+        popmod = ET.SubElement(coalescent, "populationModel", {
+            "id": "ConstantPopulation:beastlingTree",
+            "spec": "ConstantPopulation",
+            })
+        ET.SubElement(popmod, "parameter", {
+            "idref": "popSize.t:beastlingTree",
+            "name": "popSize",
+            })
+        ET.SubElement(coalescent, "treeIntervals", {
+            "id": "TreeIntervals",
+            "spec": "TreeIntervals",
+            "tree": "@Tree.t:beastlingTree",
+            })
+

--- a/tests/configs/bad_configs/bad_treeprior.conf
+++ b/tests/configs/bad_configs/bad_treeprior.conf
@@ -1,0 +1,13 @@
+[admin]
+basename = beastling_test
+log_all = True
+log_fine_probs = False
+log_every = 100
+tree_prior = This tree prior does not exist.
+[MCMC]
+chainlength = 10
+[model model]
+data = tests/data/basic.csv
+model = covarion
+share_params = True
+

--- a/tests/configuration_tests.py
+++ b/tests/configuration_tests.py
@@ -164,6 +164,11 @@ class Tests(WithConfigAndTempDir):
         cfg = self._make_bad_cfg("bad_share_params")
         cfg.process()
 
+    @raises(KeyError)
+    def test_bad_treeprior(self):
+        cfg = self._make_bad_cfg("bad_treeprior")
+        cfg.process
+
     def test_calibration_string_formats(self):
         # Test lower bound format
         config = self._make_cfg('basic', 'calibration_lower_bound')


### PR DESCRIPTION
At some point I would like to get towards supporting `speciesnetwork` and possibly other methods for reticuate phylogenies, effectively adding new classes of phylogeny priors.

Currently, handling of trees and tree priors is done very ad-hoc inside `beastxml.py`. The first step to greater prior flexibility is therefore to separate tree handling out to separate classes/modules, as is the case already for models and clocks.

This pull request presents a start of that process. The `TreePrior` object still contains functionality that should be moved to the base classes, and the communication between configuration object and tree prior still relies heavily on the BeastXML object, but I think this provides a good basis from which to work further.